### PR TITLE
Build personal stats page

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,8 +20,8 @@
     "lucide-react": "^0.525.0",
     "next": "15.4.1",
     "react": "^19.0.0",
-    "react-contribution-viewer": "^1.1.3",
     "react-dom": "^19.0.0",
+    "react-github-calendar": "^4.5.9",
     "shiki": "^3.8.0",
     "tailwind-merge": "^3.3.1",
     "tailwindcss-motion": "^1.1.1"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,12 +38,12 @@ importers:
       react:
         specifier: ^19.0.0
         version: 19.1.0
-      react-contribution-viewer:
-        specifier: ^1.1.3
-        version: 1.1.3(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(tslib@2.8.1)
       react-dom:
         specifier: ^19.0.0
         version: 19.1.0(react@19.1.0)
+      react-github-calendar:
+        specifier: ^4.5.9
+        version: 4.5.9(react@19.1.0)
       shiki:
         specifier: ^3.8.0
         version: 3.8.0
@@ -783,9 +783,6 @@ packages:
   date-fns@4.1.0:
     resolution: {integrity: sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==}
 
-  dayjs@1.11.13:
-    resolution: {integrity: sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg==}
-
   debug@4.4.1:
     resolution: {integrity: sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==}
     engines: {node: '>=6.0'}
@@ -1327,17 +1324,20 @@ packages:
   pusher-js@8.4.0:
     resolution: {integrity: sha512-wp3HqIIUc1GRyu1XrP6m2dgyE9MoCsXVsWNlohj0rjSkLf+a0jLvEyVubdg58oMk7bhjBWnFClgp8jfAa6Ak4Q==}
 
-  react-contribution-viewer@1.1.3:
-    resolution: {integrity: sha512-W4Dq5TLOrtIyPEn420mAjUjopfKBAxH9Uc71vMahmlfdamkyJ/M9roDRRiEYbhrFTs5WJ0QvSH8zDrSXe9NuRA==}
+  react-activity-calendar@2.7.13:
+    resolution: {integrity: sha512-1ZHVgK8QJxtwG52EmcQrxhUQyN1Bv+819IPTTDAGp7Hme3h9IX2thDZJG+KnVbNQ3cjh8DQdfX4wWsTHIw75ug==}
     peerDependencies:
-      react: ^17.0.0 || ^18.0.0
-      react-dom: ^17.0.0 || ^18.0.0
-      tslib: ^1.8.1
+      react: ^18.0.0 || ^19.0.0
 
   react-dom@19.1.0:
     resolution: {integrity: sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==}
     peerDependencies:
       react: ^19.1.0
+
+  react-github-calendar@4.5.9:
+    resolution: {integrity: sha512-5Ks2vGbR4KieM0vO49hJKy6hLKpFo7kbtOg+Z67qz83VeJy094okTGLt9+k2oryN5PKfjn5sJr0UObXSvNgcNw==}
+    peerDependencies:
+      react: ^18.0.0 || ^19.0.0
 
   react@19.1.0:
     resolution: {integrity: sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==}
@@ -1444,9 +1444,6 @@ packages:
   strip-ansi@7.1.0:
     resolution: {integrity: sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==}
     engines: {node: '>=12'}
-
-  style-inject@0.3.0:
-    resolution: {integrity: sha512-IezA2qp+vcdlhJaVm5SOdPPTUu0FCEqfNSli2vRuSIBbu5Nq5UvygTk/VzeCqfLz2Atj3dVII5QBKGZRZ0edzw==}
 
   style-to-js@1.1.17:
     resolution: {integrity: sha512-xQcBGDxJb6jjFCTzvQtfiPn6YvvP2O8U1MDIPNfJQlWMYfktPy+iGsHE7cssjs7y84d9fQaK4UF3RIJaAHSoYA==}
@@ -2182,8 +2179,6 @@ snapshots:
 
   date-fns@4.1.0: {}
 
-  dayjs@1.11.13: {}
-
   debug@4.4.1:
     dependencies:
       ms: 2.1.3
@@ -2857,18 +2852,20 @@ snapshots:
     dependencies:
       tweetnacl: 1.0.3
 
-  react-contribution-viewer@1.1.3(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(tslib@2.8.1):
+  react-activity-calendar@2.7.13(react@19.1.0):
     dependencies:
-      dayjs: 1.11.13
+      date-fns: 4.1.0
       react: 19.1.0
-      react-dom: 19.1.0(react@19.1.0)
-      style-inject: 0.3.0
-      tslib: 2.8.1
 
   react-dom@19.1.0(react@19.1.0):
     dependencies:
       react: 19.1.0
       scheduler: 0.26.0
+
+  react-github-calendar@4.5.9(react@19.1.0):
+    dependencies:
+      react: 19.1.0
+      react-activity-calendar: 2.7.13(react@19.1.0)
 
   react@19.1.0: {}
 
@@ -3012,8 +3009,6 @@ snapshots:
   strip-ansi@7.1.0:
     dependencies:
       ansi-regex: 6.1.0
-
-  style-inject@0.3.0: {}
 
   style-to-js@1.1.17:
     dependencies:

--- a/src/app/(core)/stats/page.tsx
+++ b/src/app/(core)/stats/page.tsx
@@ -1,12 +1,12 @@
 "use client";
 
 import Link from "next/link";
-import { Home, Github } from "lucide-react";
+import { Github } from "lucide-react";
 import dynamic from "next/dynamic";
 
-// Dynamically import the contribution viewer to avoid SSR issues
-const ContributionViewer = dynamic(
-  () => import("react-contribution-viewer"),
+// Dynamically import the GitHub calendar to avoid SSR issues
+const GitHubCalendar = dynamic(
+  () => import("react-github-calendar"),
   { 
     ssr: false,
     loading: () => (
@@ -21,13 +21,12 @@ export default function StatsPage() {
   return (
     <main className="flex flex-col items-center justify-center min-h-screen w-full gap-y-6 px-5">
       {/* Header */}
-      <div className="max-w-[600px] flex flex-col">
-        <h2 className="font-sans text-5xl font-black pb-4 text-left text-balance">
-          Stats
-        </h2>
-        <h1 className="font-mono text-lg font-bold">
-          A glimpse into my digital footprint
-        </h1>
+      <div className="max-w-[600px] w-full flex flex-col items-start">
+        <div>
+          <h2 className="font-sans text-7xl font-black pb-10 text-left text-balance">
+            Stats
+          </h2>
+        </div>
       </div>
 
       {/* GitHub Contribution Chart */}
@@ -40,15 +39,13 @@ export default function StatsPage() {
             </h2>
           </div>
           <div className="overflow-hidden rounded-lg">
-            <ContributionViewer
+            <GitHubCalendar
               username="lermatroid"
-              isDark={true}
-              isHeader={true}
-              renderHeader={(total) => (
-                <div className="mb-4 font-mono text-sm text-muted-foreground">
-                  <span className="font-bold text-card-foreground">{total}</span> contributions in the last year
-                </div>
-              )}
+              colorScheme="dark"
+              fontSize={12}
+              blockSize={11}
+              blockMargin={4}
+              showWeekdayLabels
             />
           </div>
         </div>
@@ -152,19 +149,6 @@ export default function StatsPage() {
             </span>
           </div>
         </div>
-      </div>
-
-      {/* Navigation */}
-      <div className="flex items-start max-w-[600px] w-full">
-        <p className="font-mono font-bold">
-          <Link
-            href="/"
-            className="inline-flex items-center gap-2 border-b-2 border-foreground"
-          >
-            <Home className="w-4 h-4" />
-            Home
-          </Link>
-        </p>
       </div>
     </main>
   );


### PR DESCRIPTION
Add a new `/stats` page to display personal statistics, including a GitHub contribution chart, projects, and experience.

The page uses a grid of glass morphism cards and is a client component to support the dynamic GitHub contribution chart.